### PR TITLE
avoids copying input file paths

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,9 +25,9 @@ int main(int argc, char *argv[])
   HILEVEL = MAXLEVEL;
   //default swap is "samples become random draws from phylogeny"
   SWAPMETHOD = 2;  
-  strcpy(PhyloFile, "phylo");
-  strcpy(SampleFile, "sample");
-  strcpy(TraitFile, "traits");
+  PhyloFile = "phylo";
+  SampleFile = "sample";
+  TraitFile = "traits";
   RNDPRUNEN = 5;
   RNDPRUNET = 3;
   MAKENODENAMES = 0;
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
       // phylo file
       if (strcmp(argv[argx], "-f") == 0)
 	{
-	  sscanf(argv[argx+1], "%s", PhyloFile);
+	  PhyloFile = argv[argx+1];
 	}
 
       if (strcmp(argv[argx],"-n") == 0)
@@ -114,13 +114,13 @@ int main(int argc, char *argv[])
       // sample file
       if (strcmp(argv[argx], "-s") == 0)
 	{
-	  sscanf(argv[argx+1], "%s", SampleFile);
+	  SampleFile = argv[argx+1];
 	}
 
       // traits file
       if (strcmp(argv[argx], "-t") == 0)
 	{
-	  sscanf(argv[argx+1], "%s", TraitFile);
+	  TraitFile = argv[argx+1];
 	}
 
       // Ignore branch lengths in node calculations and taxon distances (traits)

--- a/src/phylocom.h
+++ b/src/phylocom.h
@@ -236,9 +236,9 @@ FILE *Fm;   // pointer to means
 FILE *Fc;   // pointer to traits
 FILE *Fa;   // pointer to age file
 
-char PhyloFile[50]; // default name
-char SampleFile[50]; // default name
-char TraitFile[50]; // default name
+char * PhyloFile; // default name
+char * SampleFile; // default name
+char * TraitFile; // default name
 //int UseFy; // switch for using .fy format input
 int NoBL; // switch for ignoring branch lenghts
 int Droptail; // switch for dropping the root tail


### PR DESCRIPTION
There is no need to limit input file paths to 50 characters. Instead, the pointers can simply be re-assigned, both for the defaults with the static strings, as well as for the command line arguments.

fixes #31 